### PR TITLE
Use IHeaderDictionary.Append

### DIFF
--- a/Oqtane.Server/Pages/Files.cshtml.cs
+++ b/Oqtane.Server/Pages/Files.cshtml.cs
@@ -96,7 +96,7 @@ namespace Oqtane.Pages
                             }
                             else
                             {
-                                HttpContext.Response.Headers.Add(HeaderNames.ETag, etag);
+                                HttpContext.Response.Headers.Append(HeaderNames.ETag, etag);
                                 return PhysicalFile(filepath, file.GetMimeType());
                             }
                         }


### PR DESCRIPTION
`Use IHeaderDictionary.Append or the indexer to append or set headers. IDictionary.Add will throw an ArgumentException when attempting to add a duplicate key.`

This PR clears up this warning message.