### PR TITLE
Fixes #4762: Update interop.js ScrollTo function for modal

### DIFF
--- a/Oqtane.Maui/wwwroot/js/interop.js
+++ b/Oqtane.Maui/wwwroot/js/interop.js
@@ -423,13 +423,19 @@ Oqtane.Interop = {
             behavior: behavior
         });
     },
-    scrollToId: function (id) {
-        var element = document.getElementById(id);
-        if (element instanceof HTMLElement) {
-            element.scrollIntoView({
-                behavior: "smooth",
-                block: "start",
-                inline: "nearest"
+    scrollTo: function (top, left, behavior) {
+        const modal = document.querySelector('.modal');
+        if (modal) {
+            modal.scrollTo({
+                top: top,
+                left: left,
+                behavior: behavior
+            });
+        } else {
+            window.scrollTo({
+                top: top,
+                left: left,
+                behavior: behavior
             });
         }
     },


### PR DESCRIPTION
Fixes #4762

Adds check for `.modal` class and if the call to the function ScrollTo happens inside a modal it will scroll to the top of the modal.
